### PR TITLE
Fix re queue getting triggered mid game

### DIFF
--- a/src/Client/Module/Modules/AutoGG/AutoGGListener.hpp
+++ b/src/Client/Module/Modules/AutoGG/AutoGGListener.hpp
@@ -22,7 +22,34 @@ class AutoGGListener : public Listener {
         // TODO: add support for other servers (look for "won the game" text)
         if (id == MinecraftPacketIds::PlaySoundA) {
             auto *pkt = reinterpret_cast<PlaySoundPacket *>(event.getPacket());
-            if (pkt->mName == "ui.toast.challenge_complete_java" || pkt->mName == "raid.horn") {
+            if (pkt->mName == "ui.toast.challenge_complete_java") {
+                triggered = true;
+            }
+
+
+            if (triggered) {
+                std::string win_message = module->settings.getSettingByName<std::string>("text")->value;
+                if (!win_message.empty()) {
+                    auto player = SDK::clientInstance->getLocalPlayer();
+                    std::shared_ptr<Packet> packet = SDK::createPacket(9);
+                    auto *text = reinterpret_cast<TextPacket *>(packet.get());
+
+
+                    text->type = TextPacketType::CHAT;
+                    text->message = win_message;
+                    text->platformId = "";
+                    text->translationNeeded = false;
+                    text->xuid = "";
+                    text->name = player->playerName;
+
+                    SDK::clientInstance->getPacketSender()->sendToServer(text);
+                }
+            }
+        }
+    
+        else if (id == MinecraftPacketIds::Text) {
+            auto *pkt = reinterpret_cast<TextPacket *>(event.getPacket());
+            if (pkt->message == "§c§l» §r§c§lGame OVER!") {
                 triggered = true;
             }
 
@@ -47,7 +74,6 @@ class AutoGGListener : public Listener {
             }
         }
     }
-
     void onPacketSend(PacketEvent &event) override {
         /*if (event.getPacket()->getId() == MinecraftPacketIds::Text) {
             TextPacket *pkt = reinterpret_cast<TextPacket *>(event.getPacket());

--- a/src/Client/Module/Modules/AutoRQ/AutoRQListener.hpp
+++ b/src/Client/Module/Modules/AutoRQ/AutoRQListener.hpp
@@ -33,11 +33,11 @@ class AutoRQListener : public Listener {
     void onPacketReceive(PacketEvent &event) override {
         MinecraftPacketIds id = event.getPacket()->getId();
 
-        if (id == MinecraftPacketIds::PlaySoundA) {
-            auto *pkt = reinterpret_cast<PlaySoundPacket *>(event.getPacket());
-
-            if (pkt->mName == "raid.horn" ||
-                pkt->mName == "mob.ghast.fireball") {
+        if (id == MinecraftPacketIds::SetTitle) {
+            auto *pkt = reinterpret_cast<SetTitlePacket *>(event.getPacket());
+            
+            if (pkt->text == "§6§l»§r§c Game Over §6§l«" ||
+                pkt->text == "§6§l»§r§c Game Over §6§l«") {
                 triggered = true;
                 std::shared_ptr<Packet> packet = SDK::createPacket(77);
                 auto* command_packet = reinterpret_cast<CommandRequestPacket*>(packet.get());

--- a/src/Client/Module/Modules/AutoRQ/AutoRQListener.hpp
+++ b/src/Client/Module/Modules/AutoRQ/AutoRQListener.hpp
@@ -33,11 +33,10 @@ class AutoRQListener : public Listener {
     void onPacketReceive(PacketEvent &event) override {
         MinecraftPacketIds id = event.getPacket()->getId();
 
-        if (id == MinecraftPacketIds::SetTitle) {
-            auto *pkt = reinterpret_cast<SetTitlePacket *>(event.getPacket());
-            
-            if (pkt->text == "§6§l»§r§c Game Over §6§l«" ||
-                pkt->text == "§6§l»§r§c Game Over §6§l«") {
+        if (id == MinecraftPacketIds::Text) {
+            auto *pkt = reinterpret_cast<TextPacket *>(event.getPacket());
+
+            if (pkt->message == "§c§l» §r§c§lGame OVER!") {
                 triggered = true;
                 std::shared_ptr<Packet> packet = SDK::createPacket(77);
                 auto* command_packet = reinterpret_cast<CommandRequestPacket*>(packet.get());
@@ -53,7 +52,7 @@ class AutoRQListener : public Listener {
             } //std::cout << pkt->mName << std::endl;
 
         }
-        else if (id == MinecraftPacketIds::Text) {
+        if (id == MinecraftPacketIds::Text) {
             auto* pkt = reinterpret_cast<TextPacket*>(event.getPacket());
             //if (pkt->type == TextPacketType::SYSTEM) {
                 std::string textToCheck = "You are connected to server name ";


### PR DESCRIPTION
This fixes the bug where auto re queue gets triggered mid game (bedwars and ground wars),
changed the detection system for auto re-q and GG

from: set title 
to: Chat message

for auto re-q this means  the bridge and capture the flag will work again.
and for auto GG it means all game modes on hive will work instead of previously just half.